### PR TITLE
Fixed:Pipe中存在文件描述符丢失管理及RingBuffer中右值功能使用问题

### DIFF
--- a/src/Pipe.cpp
+++ b/src/Pipe.cpp
@@ -33,19 +33,27 @@ bool Pipe::Create()
 	}
 
 	if (again == 0) {
+		rp.Close();
+		wp.Close();
 		return false;
 	}
     
 	if (!rp.Listen(1)) {
+		rp.Close();
+		wp.Close();
 		return false;
 	}
       
 	if (!wp.Connect("127.0.0.1", port)) {
+		rp.Close();
+		wp.Close();
 		return false;
 	}
 
 	pipe_fd_[0] = rp.Accept();
+	rp.Close();
 	if (pipe_fd_[0] < 0) {
+		wp.Close();
 		return false;
 	}
 

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -26,12 +26,12 @@ public:
 
 	bool Push(const T& data) 
 	{ 
-		return pushData(std::forward<T>(data)); 
+		return pushData(data);
 	} 	
 
 	bool Push(T&& data) 
 	{ 
-		return PushData(data); 
+		return PushData(std::move(data));
 	} 
         
 	bool Pop(T& data)


### PR DESCRIPTION
Bug:Pipe中存在文件描述符的资源未回收。
泄漏原因(建议使用RAII):
1. 失败的条件下，未正常关闭已打开的socket文件描述符。
2. 成功的情况下，Listen的那个socket文件描述符失去它的引用管理而资源未回收。

优化:
在RingBuffer中，std::forward、std::move以及万能引用、右值引用使用失败。
参考资料:
https://github.com/kelthuzadx/EffectiveModernCppChinese中的条款23、条款24、条款25
